### PR TITLE
Visualization of the loss gradiens

### DIFF
--- a/PINNFramework/BoundaryCondition.py
+++ b/PINNFramework/BoundaryCondition.py
@@ -22,7 +22,7 @@ class DirichletBC(BoundaryCondition):
 
     def __call__(self, x, model):
         prediction = model(x)  # is equal to y
-        return self.weight * self.norm(prediction, self.func(x))
+        return self.norm(prediction, self.func(x))
 
 
 class NeumannBC(BoundaryCondition):
@@ -59,7 +59,7 @@ class NeumannBC(BoundaryCondition):
         grad_y = grad_y[:,self.begin:self.end]
         self.normal_vector.to(y.device)  # move normal vector to the correct device
         y_dn = grad_y @ self.normal_vector
-        return self.weight * self.norm(y_dn, self.func(x))
+        return self.norm(y_dn, self.func(x))
 
 
 class RobinBC(BoundaryCondition):
@@ -95,7 +95,7 @@ class RobinBC(BoundaryCondition):
         grad_y = grad_y[:, self.begin:self.end]
         self.normal_vector.to(y.device)  # move normal vector to the correct device
         y_dn = grad_y @ self.normal_vector
-        return self.weight * self.norm(y_dn, self.func(x, y))
+        return self.norm(y_dn, self.func(x, y))
 
 
 class PeriodicBC(BoundaryCondition):
@@ -145,6 +145,6 @@ class TimeDerivativeBC(BoundaryCondition):
         pred = model(x)
         grads = ones(pred.shape, device=pred.device)
         pred_dt = grad(pred, x, create_graph=True, grad_outputs=grads)[0][:, -1]
-        pred_dt = pred_dt.reshape(-1,1)
-        return self.weight * self.norm(pred_dt, dt_y)
+        pred_dt = pred_dt.reshape(-1, 1)
+        return self.norm(pred_dt, dt_y)
 

--- a/PINNFramework/HPMLoss.py
+++ b/PINNFramework/HPMLoss.py
@@ -29,4 +29,4 @@ class HPMLoss(PDELoss):
         time_derivative = hpm_input[:, -1]
         input = hpm_input[:, :-1]
         hpm_output = self.hpm_model(input)
-        return self.weight * self.norm(time_derivative, hpm_output)
+        return self.norm(time_derivative, hpm_output)

--- a/PINNFramework/InitalCondition.py
+++ b/PINNFramework/InitalCondition.py
@@ -26,4 +26,4 @@ class InitialCondition(LossTerm):
         gt_y (Tensor): ground true values for the initial state
         """
         prediction = model(x)
-        return self.weight * self.norm(prediction, gt_y)
+        return self.norm(prediction, gt_y)

--- a/PINNFramework/PDELoss.py
+++ b/PINNFramework/PDELoss.py
@@ -30,4 +30,4 @@ class PDELoss(LossTerm):
         u = model.forward(x)
         pde_residual = self.pde(x, u, **kwargs)
         zeros = torch.zeros(pde_residual.shape, device=pde_residual.device)
-        return self.weight * self.norm(pde_residual, zeros)
+        return self.norm(pde_residual, zeros)

--- a/examples/1D_Schroedinger/1D_Schroedinger.py
+++ b/examples/1D_Schroedinger/1D_Schroedinger.py
@@ -1,4 +1,6 @@
 import sys
+from argparse import ArgumentParser
+
 import numpy as np
 import scipy.io
 from pyDOE import lhs
@@ -94,20 +96,31 @@ class PDEDataset(Dataset):
 
 
 if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--num_epochs", dest="num_epochs", type=int, default=10000, help='Number of training iterations')
+    parser.add_argument('--n0', dest='n0', type=int, default=50, help='Number of input points for initial condition')
+    parser.add_argument('--nb', dest='nb', type=int, default=50, help='Number of input points for boundary condition')
+    parser.add_argument('--nf', dest='nf', type=int, default=20000, help='Number of input points for pde loss')
+    parser.add_argument('--num_hidden', dest='num_hidden', type=int, default=4, help='Number of hidden layers')
+    parser.add_argument('--hidden_size', dest='hidden_size', type=int, default=100, help='Size of hidden layers')
+    parser.add_argument('--annealing', dest='annealing', type=int, default=0, help='Enables annealing with 1')
+    parser.add_argument('--annealing_cycle', dest='annealing_cycle', type=int, default=5, help='Cycle of lr annealing')
+    parser.add_argument('--track_gradient', dest='track_gradient', default=1, help='Enables tracking of the gradients')
+    args = parser.parse_args()
     # Domain bounds
     lb = np.array([-5.0, 0.0])
     ub = np.array([5.0, np.pi / 2])
     # initial condition
-    ic_dataset = InitialConditionDataset(n0=50)
+    ic_dataset = InitialConditionDataset(n0=args.n0)
     initial_condition = pf.InitialCondition(ic_dataset, name='Initial condition')
     # boundary conditions
-    bc_dataset = BoundaryConditionDataset(nb=50, lb=lb, ub=ub)
+    bc_dataset = BoundaryConditionDataset(nb=args.nb, lb=lb, ub=ub)
     periodic_bc_u = pf.PeriodicBC(bc_dataset, 0, "u periodic boundary condition")
     periodic_bc_v = pf.PeriodicBC(bc_dataset, 1, "v periodic boundary condition")
     periodic_bc_u_x = pf.PeriodicBC(bc_dataset, 0, "u_x periodic boundary condition", 1, 0)
     periodic_bc_v_x = pf.PeriodicBC(bc_dataset, 1, "v_x periodic boundary condition", 1, 0)
     # PDE
-    pde_dataset = PDEDataset(20000, lb, ub)
+    pde_dataset = PDEDataset(args.nf, lb, ub)
 
 
     def schroedinger1d(x, u):
@@ -139,12 +152,22 @@ if __name__ == "__main__":
 
 
     pde_loss = pf.PDELoss(pde_dataset, schroedinger1d, name='1D Schrodinger')
-    model = pf.models.MLP(input_size=2, output_size=2, hidden_size=100, num_hidden=4, lb=lb, ub=ub)
+    model = pf.models.MLP(input_size=2,
+                          output_size=2,
+                          hidden_size=args.hidden_size,
+                          num_hidden=args.num_hidden,
+                          lb=lb,
+                          ub=ub)
+
+    logger = pf.WandbLogger('1D Schrödinger Equation', args, 'aipp')
     pinn = pf.PINN(model, 2, 2, pde_loss, initial_condition, [periodic_bc_u,
                                                               periodic_bc_v,
                                                               periodic_bc_u_x,
                                                               periodic_bc_v_x], use_gpu=True)
-    pinn.fit(50000, checkpoint_path='checkpoint.pt', restart=True)
+    pinn.fit(args.num_epochs, checkpoint_path='checkpoint.pt',
+             restart=False, logger=logger, activate_annealing=args.annealing, annealing_cycle=args.annealing_cycle,
+             writing_cycle=500,
+             track_gradient=args.track_gradient)
     pinn.load_model('best_model_pinn.pt')
 
     # Plotting
@@ -168,8 +191,8 @@ if __name__ == "__main__":
     H_pred = np.sqrt(pred_u ** 2 + pred_v**2)
     H_pred = H_pred.reshape(X.shape)
     plt.imshow(H_pred.T, interpolation='nearest', cmap='YlGnBu',
-                  extent= [lb[1], ub[1], lb[0], ub[0]],
+                  extent=[lb[1], ub[1], lb[0], ub[0]],
                   origin='lower', aspect='auto')
     plt.colorbar()
     plt.show()
-
+W


### PR DESCRIPTION
By this pull request, it's allowed to track the gradients of the loss terms by the logger. You can enable the tracking of the loss term gradients by switching a flag in the ```pinn.fit()``` function. 
```python
    pinn.fit(args.num_epochs,track_gradient=args.track_gradient)
```
Furthermore, the 1D Schrodinger example is extended by this option. 
